### PR TITLE
Improvements to Salt implemented for converting Ridges to relANNIS 4

### DIFF
--- a/salt-graph/src/main/java/de/hu_berlin/german/korpling/saltnpepper/salt/graph/modules/GraphTraverserModule.java
+++ b/salt-graph/src/main/java/de/hu_berlin/german/korpling/saltnpepper/salt/graph/modules/GraphTraverserModule.java
@@ -36,6 +36,8 @@ import de.hu_berlin.german.korpling.saltnpepper.salt.graph.Node;
 import de.hu_berlin.german.korpling.saltnpepper.salt.graph.exceptions.GraphTraverserException;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles the traversal of a graph.
@@ -331,6 +333,7 @@ public class GraphTraverserModule extends GraphModule {
 					entry.order++;
 				}
 				catch (ConcurrentModificationException ex) {
+					LoggerFactory.getLogger(GraphTraverserModule.class).warn("Graph was changed during traversal", ex);
 					// use fallback
 					entry.iterator = null;
 				}

--- a/salt-graph/src/main/java/de/hu_berlin/german/korpling/saltnpepper/salt/graph/modules/GraphTraverserModule.java
+++ b/salt-graph/src/main/java/de/hu_berlin/german/korpling/saltnpepper/salt/graph/modules/GraphTraverserModule.java
@@ -34,6 +34,8 @@ import de.hu_berlin.german.korpling.saltnpepper.salt.graph.Graph;
 import de.hu_berlin.german.korpling.saltnpepper.salt.graph.GraphTraverseHandler;
 import de.hu_berlin.german.korpling.saltnpepper.salt.graph.Node;
 import de.hu_berlin.german.korpling.saltnpepper.salt.graph.exceptions.GraphTraverserException;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
 
 /**
  * Handles the traversal of a graph.
@@ -46,7 +48,8 @@ public class GraphTraverserModule extends GraphModule {
 	 * Stores all used traverseIds to the corresponding traverse callback
 	 * handler. This is used, to check, that an id is not used twice.
 	 */
-	private volatile HashMap<GraphTraverseHandler, EList<String>> traverseIdTable = new HashMap<GraphTraverseHandler, EList<String>>();
+	private HashMap<GraphTraverseHandler, EList<String>> traverseIdTable 
+			= new HashMap<GraphTraverseHandler, EList<String>>();
 
 	/**
 	 * Traverses a graph in the given order traverseType and starts traversing
@@ -164,22 +167,8 @@ public class GraphTraverserModule extends GraphModule {
 		traverser.traverseHandler = traverseHandler;
 		traverser.isCycleSafe = isCycleSafe;
 		traverser.setGraph(this.getGraph());
-		Thread traverserThread = new Thread(traverser, "GraphTraverserThread_"
-				+ traverseId);
-
-		traverser.traverselock.lock();
-
-		traverserThread.start();
-		// traverserThread.join();
-		try {
-			traverser.traverseFinished.await();
-		} catch (InterruptedException e) {
-			throw new GraphTraverserException(
-					"An exception occurs while traversing the graph '"
-							+ this.getGraph().getId() + "'.", e);
-		} finally {
-			traverser.traverselock.unlock();
-		}
+		
+		traverser.run();
 
 		// clean up traverseIdTable
 		synchronized (traverseIdTable) {
@@ -286,6 +275,7 @@ public class GraphTraverserModule extends GraphModule {
 		private class NodeEntry {
 			private final Node node;
 			private int order;
+			private Iterator<Edge> iterator;
 			private Edge edge;
 
 			public NodeEntry(Node node, int order) {
@@ -322,12 +312,41 @@ public class GraphTraverserModule extends GraphModule {
 		 */
 		protected Node nextChild(NodeEntry entry) {
 			Node retVal = null;
-			List<Edge> outEdges = getGraph().getOutEdges(entry.node.getId());
-			if ((outEdges != null) && (!outEdges.isEmpty())) {
-				if (entry.order < outEdges.size()) {
-					entry.edge = outEdges.get(entry.order);
+			
+			if(entry.order == 0)
+			{
+				// set the iterator
+				List<Edge> outEdges = getGraph().getOutEdges(entry.node.getId());
+				if ((outEdges != null) && (!outEdges.isEmpty())) {
+					entry.iterator = outEdges.iterator();
+				}
+			}
+			
+			// if we already have an iterator use it
+			if(entry.iterator != null && entry.iterator.hasNext())
+			{
+				try {
+					entry.edge = entry.iterator.next();
 					retVal = entry.edge.getTarget();
 					entry.order++;
+				}
+				catch (ConcurrentModificationException ex) {
+					// use fallback
+					entry.iterator = null;
+				}
+			}
+			
+			// even if something went wrong with the iterator we should be still
+			// able to execute the code (just with less performance)
+			if(entry.iterator == null)
+			{
+				List<Edge> outEdges = getGraph().getOutEdges(entry.node.getId());
+				if ((outEdges != null) && (!outEdges.isEmpty())) {
+					if (entry.order < outEdges.size()) {
+						entry.edge = outEdges.get(entry.order);
+						retVal = entry.edge.getTarget();
+						entry.order++;
+					}
 				}
 			}
 			return (retVal);

--- a/salt-saltCommon/src/main/java/de/hu_berlin/german/korpling/saltnpepper/salt/saltCommon/helper/modules/SDocumentStructureRootAccessor.java
+++ b/salt-saltCommon/src/main/java/de/hu_berlin/german/korpling/saltnpepper/salt/saltCommon/helper/modules/SDocumentStructureRootAccessor.java
@@ -37,6 +37,7 @@ import de.hu_berlin.german.korpling.saltnpepper.salt.saltCommon.sDocumentStructu
 import de.hu_berlin.german.korpling.saltnpepper.salt.saltCommon.sDocumentStructure.STYPE_NAME;
 import de.hu_berlin.german.korpling.saltnpepper.salt.saltCore.SNode;
 import de.hu_berlin.german.korpling.saltnpepper.salt.saltCore.SRelation;
+import java.util.LinkedHashSet;
 
 public class SDocumentStructureRootAccessor extends SDocumentStructureModule
 {
@@ -54,7 +55,8 @@ public class SDocumentStructureRootAccessor extends SDocumentStructureModule
 	@SuppressWarnings("unchecked")
 	public EList<SNode> getRootsBySRelation(STYPE_NAME sType)
 	{
-		EList<SNode> retVal= null;
+		HashSet<SNode> retSet = new LinkedHashSet<>();
+		
 		if (this.getSDocumentGraph()== null)
 			new SaltModuleException("Cannot start method please set the document graph first.");
 		
@@ -83,7 +85,6 @@ public class SDocumentStructureRootAccessor extends SDocumentStructureModule
 		}//compute all relations of subtype
 		if (relations!= null)
 		{
-			retVal= new BasicEList<SNode>();
 			HashSet<SNode> notRootElements= new HashSet<SNode>();
 			for (SRelation relation: relations)
 			{
@@ -92,12 +93,17 @@ public class SDocumentStructureRootAccessor extends SDocumentStructureModule
 					notRootElements.add(relation.getSTarget());
 				//if source is not also a destination
 				if (	(!notRootElements.contains(relation.getSSource())) &&
-						(!retVal.contains(relation.getSSource())))
-					retVal.add(relation.getSSource());
+						(!retSet.contains(relation.getSSource())))
+					retSet.add(relation.getSSource());
 				//remove wrong stored nodes in retList
-				if (retVal.contains(relation.getSTarget()))
-					retVal.remove(relation.getSTarget());
+				if (retSet.contains(relation.getSTarget()))
+					retSet.remove(relation.getSTarget());
 			}
+		}
+		EList<SNode> retVal= null;
+		if(!retSet.isEmpty())
+		{
+			retVal= new BasicEList<>(retSet);
 		}
 		return (retVal);
 	}

--- a/salt-saltCommon/src/main/java/de/hu_berlin/german/korpling/saltnpepper/salt/saltCommon/sDocumentStructure/impl/SDocumentGraphImpl.java
+++ b/salt-saltCommon/src/main/java/de/hu_berlin/german/korpling/saltnpepper/salt/saltCommon/sDocumentStructure/impl/SDocumentGraphImpl.java
@@ -1088,14 +1088,6 @@ public class SDocumentGraphImpl extends SGraphImpl implements SDocumentGraph {
 	}
 // ============================ end: handling specific relations
 	
-	protected void finalize() throws Throwable 
-	{
-	    try {
-	    } finally {
-	        super.finalize();
-	    }
-	}
-	
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->


### PR DESCRIPTION
These are some improvements to Salt I made to better support relANNIS conversion:

- don't create threads in GraphTraverserModule traverse() function
- use iterator when iterating over all outgoing edges instead of having a counter variable and using get(idx) on the list
- make sure SDocumentStructureRootAccessor#getSRootsByRelation() returns a list without duplicates
- removed empty finalize() function in SDocumentGraphImpl: every class that implements finalize can't be deleted directly by the GC but will be put in a background thread that executes the finalize method in some point of the future