### PR TITLE
Allow to serialize/deserialize multiple root objects per Salt XMI file

### DIFF
--- a/salt-api/nb-configuration.xml
+++ b/salt-api/nb-configuration.xml
@@ -20,12 +20,5 @@ Any value defined here will override the pom.xml file value but is only applicab
         <org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>false</org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>
         <org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>80</org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>
         <org-netbeans-modules-editor-indent.CodeStyle.project.text-line-wrap>none</org-netbeans-modules-editor-indent.CodeStyle.project.text-line-wrap>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeElseOnNewLine>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeElseOnNewLine>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeFinallyOnNewLine>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeFinallyOnNewLine>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeCatchOnNewLine>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeCatchOnNewLine>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.classDeclBracePlacement>NEW_LINE</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.classDeclBracePlacement>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeWhileOnNewLine>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.placeWhileOnNewLine>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.otherBracePlacement>NEW_LINE</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.otherBracePlacement>
-        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.methodDeclBracePlacement>NEW_LINE</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.methodDeclBracePlacement>
     </properties>
 </project-shared-configuration>

--- a/salt-api/src/main/java/org/corpus_tools/salt/util/SaltUtil.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/util/SaltUtil.java
@@ -376,7 +376,7 @@ public class SaltUtil {
 		}
 		return (globalId.toString());
 	}
-
+	
 	// ================================================> Persistence SaltXML
 	/**
 	 * Loads an object coming from a SaltXML (.{@link #FILE_ENDING_SALT_XML})
@@ -387,6 +387,24 @@ public class SaltUtil {
 	 * @return loaded object
 	 */
 	public static Object load(URI location) {
+		List<Object> objects = loadObjects(location);
+		if(objects == null || objects.isEmpty()) {
+			return null;
+		} else {
+			return objects.get(0);
+		}
+	}
+
+	// ================================================> Persistence SaltXML
+	/**
+	 * Loads a list of root objects coming from a SaltXML (.{@link #FILE_ENDING_SALT_XML})
+	 * and returns it.
+	 * 
+	 * @param objectURI
+	 *            {@link URI} to SaltXML file containing the object
+	 * @return loaded objects
+	 */
+	public static List<Object> loadObjects(URI location) {
 		if (location == null) {
 			throw new SaltResourceException("Cannot load Salt object, because the given uri is null.");
 		}
@@ -431,7 +449,7 @@ public class SaltUtil {
 				throw new SaltResourceException("Cannot load Salt object from file'" + objectFile + "', because of a nested exception. ", e);
 			}
 		}
-		return ((Object) contentHandler.getSaltObject());
+		return contentHandler.getRootObjects();
 	}
 
 	/**

--- a/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Handler.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Handler.java
@@ -70,7 +70,7 @@ public class SaltXML10Handler extends DefaultHandler2 implements SaltXML10Dictio
 	
 	private static final Pattern RELATION_REF = Pattern.compile("/[0-9]*/@((sCorpusGraphs)|(nodes))\\.(?<nr>[0-9]+)"); 
 	
-	private static final Pattern LAYER_REF = Pattern.compile("/[0-9]*/@layers.");
+	private static final Pattern LAYER_REF = Pattern.compile("/[0-9]*/@layers\\.");
 	
 	/**
 	 * Adds an object to the list of root objects if the current container stack is empty.

--- a/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Handler.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Handler.java
@@ -82,6 +82,12 @@ public class SaltXML10Handler extends DefaultHandler2 implements SaltXML10Dictio
 		// object is a root.
 		if(currentContainer.isEmpty()) {
 			rootObjects.add(object);
+			
+			// if there is a new root object all the indexes must be reset
+			nodes.clear();
+			relations.clear();
+			layers.clear();
+			saltProject = null;
 		}
 		currentContainer.push(object);
 	}

--- a/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Handler.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Handler.java
@@ -69,6 +69,9 @@ public class SaltXML10Handler extends DefaultHandler2 implements SaltXML10Dictio
 	private final List<Object> rootObjects = new LinkedList<>();
 	
 	private static final Pattern RELATION_REF = Pattern.compile("/[0-9]*/@((sCorpusGraphs)|(nodes))\\.(?<nr>[0-9]+)"); 
+	
+	private static final Pattern LAYER_REF = Pattern.compile("/[0-9]*/@layers.");
+	
 	/**
 	 * Adds an object to the list of root objects if the current container stack is empty.
 	 * 
@@ -167,7 +170,7 @@ public class SaltXML10Handler extends DefaultHandler2 implements SaltXML10Dictio
 			}
 			String layersStr = attributes.getValue(ATT_LAYERS);
 			if (layersStr != null) {
-				layersStr = layersStr.replace("//@layers.", "");
+				layersStr = LAYER_REF.matcher(layersStr).replaceAll("");
 				String[] layerNums = layersStr.split(" ");
 				if (layerNums.length > 0) {
 					for (String layerNum : layerNums) {
@@ -240,7 +243,7 @@ public class SaltXML10Handler extends DefaultHandler2 implements SaltXML10Dictio
 			}
 			String layersStr = attributes.getValue(ATT_LAYERS);
 			if (layersStr != null) {
-				layersStr = layersStr.replace("//@layers.", "");
+				layersStr = LAYER_REF.matcher(layersStr).replaceAll("");
 				String[] layerNums = layersStr.split(" ");
 				if (layerNums.length > 0) {
 					for (String layerNum : layerNums) {

--- a/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Handler.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Handler.java
@@ -87,6 +87,7 @@ public class SaltXML10Handler extends DefaultHandler2 implements SaltXML10Dictio
 			nodes.clear();
 			relations.clear();
 			layers.clear();
+			layerIdx = 0;
 			saltProject = null;
 		}
 		currentContainer.push(object);

--- a/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Handler.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Handler.java
@@ -73,16 +73,17 @@ public class SaltXML10Handler extends DefaultHandler2 implements SaltXML10Dictio
 	private static final Pattern LAYER_REF = Pattern.compile("/[0-9]*/@layers\\.");
 	
 	/**
-	 * Adds an object to the list of root objects if the current container stack is empty.
+	 * Adds an object. Also adds it to the list of root objects if the current container stack is empty.
 	 * 
 	 **/
-	private void addRootObject(Object rootObject) {
+	private void addObject(Object object) {
 		
 		// Only add the object if the current container stack is empty, thus this
 		// object is a root.
 		if(currentContainer.isEmpty()) {
-			rootObjects.add(rootObject);
+			rootObjects.add(object);
 		}
+		currentContainer.push(object);
 	}
 
 	/**
@@ -125,24 +126,21 @@ public class SaltXML10Handler extends DefaultHandler2 implements SaltXML10Dictio
 	public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
 		if (TAG_SALT_PROJECT_FULL.equals(qName)) {
 			SaltProject project = SaltFactory.createSaltProject();
-			addRootObject(project);
-			saltProject = project;
 			String sName = attributes.getValue(ATT_SNAME);
 			if (sName != null) {
 				project.setName(sName);
 			}
-			currentContainer.push(project);
+			addObject(project);
+			saltProject = project;
 		} else if (TAG_SCORPUS_GRAPH.equals(qName)) {
 			SCorpusGraph graph = SaltFactory.createSCorpusGraph();
-			addRootObject(graph);
+			addObject(graph);
 			if (saltProject != null) {
 				saltProject.addCorpusGraph(graph);
 			}
-			currentContainer.push(graph);
 		} else if (TAG_SDOCUMENT_GRAPH.equals(qName)) {
 			SDocumentGraph graph = SaltFactory.createSDocumentGraph();
-			addRootObject(graph);
-			currentContainer.push(graph);
+			addObject(graph);
 		} else if (TAG_NODES.equals(qName)) {
 			SNode sNode = null;
 			String type = attributes.getValue(ATT_TYPE);
@@ -164,8 +162,7 @@ public class SaltXML10Handler extends DefaultHandler2 implements SaltXML10Dictio
 				sNode = SaltFactory.createSDocument();
 			}
 			if (sNode != null) {
-				addRootObject(sNode);
-				currentContainer.push(sNode);
+				addObject(sNode);
 				nodes.add(sNode);
 			}
 			String layersStr = attributes.getValue(ATT_LAYERS);
@@ -234,11 +231,10 @@ public class SaltXML10Handler extends DefaultHandler2 implements SaltXML10Dictio
 				} else if (targetNode == null) {
 					throw new SaltResourceException("Cannot find a target node '" + target + "' for relation. ");
 				} else {
-					addRootObject(sRel);
+					addObject(sRel);
 					sRel.setSource(sourceNode);
 					sRel.setTarget(targetNode);
 					relations.add(sRel);
-					currentContainer.push(sRel);
 				}
 			}
 			String layersStr = attributes.getValue(ATT_LAYERS);
@@ -316,8 +312,7 @@ public class SaltXML10Handler extends DefaultHandler2 implements SaltXML10Dictio
 						// "' and could not be added twice.");
 					}
 				}
-				addRootObject(label);
-				currentContainer.push(label);
+				addObject(label);
 			}
 		} else if (TAG_LAYERS.equals(qName)) {
 			SLayer layer = layers.get(layerIdx.toString());

--- a/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Writer.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Writer.java
@@ -147,7 +147,9 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 			}
 		}
 		
-		writtenRootObjects = new ArrayList<>(filteredObjects.size());
+		if(writtenRootObjects == null) {
+			writtenRootObjects = new ArrayList<>(filteredObjects.size());
+		}
 		
 		for(Object o : filteredObjects) {
 			if(o instanceof SaltProject) {

--- a/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Writer.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Writer.java
@@ -687,4 +687,16 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 		}
 		xml.writeEndElement();
 	}
+	
+	public static void writeXMIRootElement(XMLStreamWriter xml)
+			throws XMLStreamException
+	{
+		xml.writeStartElement(NS_XMI, "XMI", NS_VALUE_XMI);
+		xml.writeNamespace(NS_SDOCUMENTSTRUCTURE, NS_VALUE_SDOCUMENTSTRUCTURE);
+		xml.writeNamespace(NS_XMI, NS_VALUE_XMI);
+		xml.writeNamespace(NS_XSI, NS_VALUE_XSI);
+		xml.writeNamespace(NS_SALTCORE, NS_VALUE_SALTCORE);
+		xml.writeAttribute(NS_VALUE_XMI, ATT_XMI_VERSION, "2.0");
+		xml.writeCharacters("\n");
+	}
 }

--- a/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Writer.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Writer.java
@@ -468,7 +468,7 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 		}
 		return (retVal);
 	}
-
+	
 	/**
 	 * Writes the passed node object to the passed {@link XMLStreamWriter}.
 	 * 
@@ -480,6 +480,22 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 	 * @throws XMLStreamException
 	 */
 	public void writeNode(XMLStreamWriter xml, Node node, Map<? extends Layer, Integer> layerPositions) throws XMLStreamException {
+		writeNode(xml, null, node, layerPositions);
+	}
+
+	/**
+	 * Writes the passed node object to the passed {@link XMLStreamWriter}.
+	 * 
+	 * @param node
+	 *            to be persist
+	 * @param rootIndex The index of the root object in the XML document.
+	 *					If there is only one root object in the XML file this can be null.
+	 * @param xml
+	 *            stream to write data to
+	 * @param layerPositions
+	 * @throws XMLStreamException
+	 */
+	public void writeNode(XMLStreamWriter xml, Integer rootIndex, Node node, Map<? extends Layer, Integer> layerPositions) throws XMLStreamException {
 		if (isPrettyPrint) {
 			xml.writeCharacters("\n");
 			xml.writeCharacters("\t");
@@ -516,7 +532,11 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 					layerAtt.append(" ");
 				}
 				isFirst = false;
-				layerAtt.append("//@layers.");
+				layerAtt.append("/");
+				if(rootIndex != null) {
+					layerAtt.append(rootIndex);
+				}
+				layerAtt.append("/@layers.");
 				layerAtt.append(layerPositions.get(layerIt.next()));
 			}
 			xml.writeAttribute(ATT_LAYERS, layerAtt.toString());
@@ -538,7 +558,7 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 		}
 		xml.writeEndElement();
 	}
-
+	
 	/**
 	 * Writes the passed relation object to the passed {@link XMLStreamWriter}.
 	 * 
@@ -552,6 +572,24 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 	 * @throws XMLStreamException
 	 */
 	public void writeRelation(XMLStreamWriter xml, Relation relation, Map<? extends Node, Integer> nodePositions, Map<? extends Layer, Integer> layerPositions) throws XMLStreamException {
+		writeRelation(xml, null, relation, nodePositions, layerPositions);
+	}
+
+	/**
+	 * Writes the passed relation object to the passed {@link XMLStreamWriter}.
+	 * 
+	 * @param relation
+	 *            to be persist
+	 * @param xml
+	 *            stream to write data to
+	 * @param rootIndex The index of the root object in the XML document. 
+	 *					If there is only one root object in the XML file this can be null.
+	 * @param nodePositions
+	 *            a map containing all positions of nodes in the list of nodes
+	 * @param layerPositions
+	 * @throws XMLStreamException
+	 */
+	public void writeRelation(XMLStreamWriter xml, Integer rootIndex, Relation relation, Map<? extends Node, Integer> nodePositions, Map<? extends Layer, Integer> layerPositions) throws XMLStreamException {
 		if (isPrettyPrint) {
 			xml.writeCharacters("\n");
 			xml.writeCharacters("\t");
@@ -582,9 +620,14 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 		xml.writeAttribute(NS_VALUE_XSI, ATT_XSI_TYPE, type);
 		int sourcePos = nodePositions.get(relation.getSource());
 		int targetPos = nodePositions.get(relation.getTarget());
-		xml.writeAttribute(ATT_SOURCE, "//@nodes." + sourcePos);
-		xml.writeAttribute(ATT_TARGET, "//@nodes." + targetPos);
-
+		if(rootIndex == null) {
+			xml.writeAttribute(ATT_SOURCE, "//@nodes." + sourcePos);
+			xml.writeAttribute(ATT_TARGET, "//@nodes." + targetPos);
+		} else {
+			xml.writeAttribute(ATT_SOURCE, "/" + rootIndex + "/@nodes." + sourcePos);
+			xml.writeAttribute(ATT_TARGET, "/" + rootIndex + "/@nodes." + targetPos);
+		}
+		
 		// write layers
 		if (relation.getLayers().size() > 0) {
 			StringBuilder layerAtt = new StringBuilder();
@@ -595,7 +638,11 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 					layerAtt.append(" ");
 				}
 				isFirst = false;
-				layerAtt.append("//@layers.");
+				layerAtt.append("/");
+				if(rootIndex != null) {
+					layerAtt.append(rootIndex);
+				}
+				layerAtt.append("/@layers.");
 				layerAtt.append(layerPositions.get(layerIt.next()));
 			}
 			xml.writeAttribute(ATT_LAYERS, layerAtt.toString());
@@ -617,7 +664,7 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 		}
 		xml.writeEndElement();
 	}
-
+	
 	/**
 	 * Writes the passed relation object to the passed {@link XMLStreamWriter}.
 
@@ -632,7 +679,31 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 	 *            list of relations
 	 * @throws XMLStreamException
 	 */
-	public void writeLayer(XMLStreamWriter xml, Layer layer, Map<SNode, Integer> nodePositions, Map<SRelation<SNode, SNode>, Integer> relPositions) throws XMLStreamException {
+	public void writeLayer(XMLStreamWriter xml, 
+			Layer layer, Map<SNode, Integer> nodePositions, 
+			Map<SRelation<SNode, SNode>, Integer> relPositions) throws XMLStreamException {
+		writeLayer(xml, null, layer, nodePositions, relPositions);
+	}
+
+	/**
+	 * Writes the passed relation object to the passed {@link XMLStreamWriter}.
+
+	 * @param layer
+	 * @param xml
+	 *            stream to write data to
+	 * @param rootIndex The index of the root object in the XML document. 
+	 *					If there is only one root object in the XML file this can be null.
+	 * @param nodePositions
+	 *            a map containing all positions of a single node in the list of
+	 *            nodes
+	 * @param relPositions
+	 *            a map containing all positions of a single relation in the
+	 *            list of relations
+	 * @throws XMLStreamException
+	 */
+	public void writeLayer(XMLStreamWriter xml, Integer rootIndex, 
+			Layer layer, Map<SNode, Integer> nodePositions, 
+			Map<SRelation<SNode, SNode>, Integer> relPositions) throws XMLStreamException {
 		if (isPrettyPrint) {
 			xml.writeCharacters("\n");
 			xml.writeCharacters("\t");
@@ -651,7 +722,11 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 					nodeAtt.append(" ");
 				}
 				isFirst = false;
-				nodeAtt.append("//@nodes.");
+				nodeAtt.append("/");
+				if(rootIndex != null) {
+					nodeAtt.append(rootIndex);
+				}
+				nodeAtt.append("/@nodes.");
 				nodeAtt.append(nodePositions.get(nodeIt.next()));
 			}
 			xml.writeAttribute(ATT_NODES, nodeAtt.toString());

--- a/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Writer.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/util/internal/persistence/SaltXML10Writer.java
@@ -234,7 +234,6 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 			if (graph.getNodes() != null) {
 				Iterator<SNode> nodeIt = graph.getNodes().iterator();
 				Integer position = 0;
-				position = 0;
 				while (nodeIt.hasNext()) {
 					SNode node = nodeIt.next();
 					writeNode(xml, node, null);
@@ -443,6 +442,8 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 	 * <li>{@link Float} - it is prefixed with "F::"</li>
 	 * <li>{@link URI} - it is prefixed with "U::"</li>
 	 * </ul>
+	 * @param value
+	 * @return 
 	 */
 	public String marshallValue(Object value) {
 		String retVal = null;
@@ -475,9 +476,10 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 	 *            to be persist
 	 * @param xml
 	 *            stream to write data to
+	 * @param layerPositions
 	 * @throws XMLStreamException
 	 */
-	public void writeNode(XMLStreamWriter xml, Node node, Map<SLayer, Integer> layerPositions) throws XMLStreamException {
+	public void writeNode(XMLStreamWriter xml, Node node, Map<? extends Layer, Integer> layerPositions) throws XMLStreamException {
 		if (isPrettyPrint) {
 			xml.writeCharacters("\n");
 			xml.writeCharacters("\t");
@@ -546,9 +548,10 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 	 *            stream to write data to
 	 * @param nodePositions
 	 *            a map containing all positions of nodes in the list of nodes
+	 * @param layerPositions
 	 * @throws XMLStreamException
 	 */
-	public void writeRelation(XMLStreamWriter xml, Relation relation, Map<SNode, Integer> nodePositions, Map<SLayer, Integer> layerPositions) throws XMLStreamException {
+	public void writeRelation(XMLStreamWriter xml, Relation relation, Map<? extends Node, Integer> nodePositions, Map<? extends Layer, Integer> layerPositions) throws XMLStreamException {
 		if (isPrettyPrint) {
 			xml.writeCharacters("\n");
 			xml.writeCharacters("\t");
@@ -617,9 +620,8 @@ public class SaltXML10Writer implements SaltXML10Dictionary {
 
 	/**
 	 * Writes the passed relation object to the passed {@link XMLStreamWriter}.
-	 * 
-	 * @param relation
-	 *            to be persist
+
+	 * @param layer
 	 * @param xml
 	 *            stream to write data to
 	 * @param nodePositions

--- a/salt-api/src/test/java/org/corpus_tools/salt/util/persistence/tests/Persist_SaltXML10_Test.java
+++ b/salt-api/src/test/java/org/corpus_tools/salt/util/persistence/tests/Persist_SaltXML10_Test.java
@@ -325,22 +325,22 @@ public class Persist_SaltXML10_Test {
 		SampleGenerator.createDocumentStructure(doc1);
 		SampleGenerator.createDocumentStructure(doc2);
 
-		File tmpFile = new File(SaltTestsUtil.getTempTestFolder("/testLoadStore") + "/MultipleContentRoots.salt");
+		File tmpFile = new File(SaltTestsUtil.getTempTestFolder("/testLoadStore_MultipleContentRoots") + "/MultipleContentRoots.salt");
 
 		XMLOutputFactory outFactory = XMLOutputFactory.newFactory();
 		try (FileOutputStream fos = new FileOutputStream(tmpFile)) {
 			
+			
+			
 			XMLStreamWriter xml = outFactory.createXMLStreamWriter(fos, "UTF-8");
+			SaltXML10Writer writer = new SaltXML10Writer();
 			
 			xml.writeStartDocument("1.0");
 			xml.writeCharacters("\n");
-			SaltXML10Writer.writeXMIRootElement(xml);
+			writer.writeXMIRootElement(xml);
 
 			// store all objects in one single file
-			SaltXML10Writer writer = new SaltXML10Writer(tmpFile);
-			writer.writeSaltProject(xml, proj);
-			writer.writeDocumentGraph(xml, doc1.getDocumentGraph());
-			writer.writeDocumentGraph(xml, doc2.getDocumentGraph());
+			writer.writeObjects(xml, proj, doc1.getDocumentGraph(), doc2.getDocumentGraph());
 			
 			xml.writeEndDocument();
 


### PR DESCRIPTION
XMI allows to have more than one root object (an object that is not contained in another object). The current implementation of the Salt serialization only supports the simple case where references are expressed with "//node.123" instead of the index of the root object (e.g. "/3/node.123").

In addition to internal code changes the SaltXML10Writer now has the "writeObjects(...)" method to write multiple objects at once and the SaltXML10Handler has the "getRootObjects()" in additon to the original "getSaltObject()".