### PR TITLE
Tokenizer, clitics- and tokenization-related fixes (replaces #89)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,13 @@
 *	artifactId:		salt-saltSample												  *
 ***********************************************************************************
 
+Version 3.0.6
+=============
+* fix #69: create StextualDS.tokenize()
+* fix #86: Tokenizer sets Italian (?) clitics to LanguageCode for Spanish
+* fix #87: Proclitics regex for French doesn't work as expected
+* Support dynamic handling of clitics in Tokenizer (set directly, read from file)
+
 Version 3.0.5
 =============
 * fix #82: GraphML serialization was invalid

--- a/salt-api/src/main/java/org/corpus_tools/salt/common/STextualDS.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/common/STextualDS.java
@@ -17,9 +17,13 @@
  */
 package org.corpus_tools.salt.common;
 
+import java.util.List;
+
 public interface STextualDS extends SSequentialDS<String, Integer>, SDocumentGraphObject {
 	public String getText();
 
 	public void setText(String text);
+	
+	public List<SToken> tokenize();
 
 } // STextualDS

--- a/salt-api/src/main/java/org/corpus_tools/salt/common/impl/STextualDSImpl.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/common/impl/STextualDSImpl.java
@@ -17,8 +17,12 @@
  */
 package org.corpus_tools.salt.common.impl;
 
+import java.util.List;
+
 import org.corpus_tools.salt.common.SDocumentGraph;
 import org.corpus_tools.salt.common.STextualDS;
+import org.corpus_tools.salt.common.SToken;
+import org.corpus_tools.salt.common.tokenizer.Tokenizer;
 import org.corpus_tools.salt.core.impl.SLayerImpl;
 import org.corpus_tools.salt.exceptions.SaltParameterException;
 import org.corpus_tools.salt.graph.Graph;
@@ -98,5 +102,18 @@ public class STextualDSImpl extends SSequentialDSImpl<String, Integer> implement
 		} else {
 			return (null);
 		}
+	}
+
+	/**
+	* Bug fix 69.
+	* Implements fast access to tokenization of a {@link STextualDS}.
+	* Simply duplicates the functionality of {@link SDocumentGraphImpl#tokenize()},
+	* but only with respect to this object.
+	*/
+	@Override
+	public List<SToken> tokenize() {
+		Tokenizer tokenizer = new Tokenizer();
+		tokenizer.setsDocumentGraph(getGraph());
+		return tokenizer.tokenize(this);
 	}
 } // STextualDSImpl

--- a/salt-api/src/main/java/org/corpus_tools/salt/common/tokenizer/Clitics.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/common/tokenizer/Clitics.java
@@ -23,7 +23,7 @@ import org.corpus_tools.salt.common.STextualDS;
 
 /**
  * Models clitics for a given language, with support for 
- * proclitics (({@link #proclitic}) and enclitics ({@link #enclitic})
+ * proclitics (({@link #proclitics}) and enclitics ({@link #enclitics})
  * in this version. Meso- and endoclitics are not yet supported.
  * <p>
  * The {@link String} representation of the respective clitics
@@ -48,24 +48,22 @@ import org.corpus_tools.salt.common.STextualDS;
 public class Clitics {
 
 	// character sequences which have to be cut off at the beginning of a word
-	private String proclitic = "";
+	private final String proclitics;
 
 	// character sequences which have to be cut off at the end of a word
-	private String enclitic = "";
+	private final String enclitics;
+	
+	public Clitics(String proclitics, String enclitics) {
+		this.proclitics = proclitics;
+		this.enclitics = enclitics;
+	}
 
-	public String getProclitic() {
-		return proclitic;
+	public String getProclitics() {
+		return proclitics;
 	}
-	public Clitics setProclitic(String pClitic) {
-		proclitic = pClitic;
-		return this;
-	}
-	public String getEnclitic() {
-		return enclitic;
-	}
-	public Clitics setEnclitic(String fClitic) {
-		enclitic = fClitic;
-		return this;
+
+	public String getEnclitics() {
+		return enclitics;
 	}
 
 }

--- a/salt-api/src/main/java/org/corpus_tools/salt/common/tokenizer/Clitics.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/common/tokenizer/Clitics.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2016 Humboldt-Universität zu Berlin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.corpus_tools.salt.common.tokenizer;
+
+import java.util.regex.Pattern;
+
+import org.corpus_tools.salt.common.STextualDS;
+
+/**
+ * Models clitics for a given language, with support for 
+ * proclitics (({@link #proclitic}) and enclitics ({@link #enclitic})
+ * in this version. Meso- and endoclitics are not yet supported.
+ * <p>
+ * The {@link String} representation of the respective clitics
+ * needs to be a regular expression, as it will be used to 
+ * {@link Pattern#compile(String)} a pattern to split the 
+ * {@link STextualDS}'s text, i.e., as below.
+ * <p>
+ * <code>
+ * Pattern.compile("^"  XClitic  "(.)$")
+ * </code>
+ * <p>
+ * Two examples for such a regex string are (<b>note the main group!</b>):
+ * <ul>
+ * <li>Enclitics for English: <code>"('(s|re|ve|d|m|em|ll)|n't)"</code></li>
+ * <li>Proclitics for French: <code>"([dcjlmnstDCJLNMST]'|[Qq]u'|[Jj]usqu'|[Ll]orsqu')"</code></li>
+ * </ul>
+ * From {@link Tokenizer}.
+ * 
+ * @author Stephan Druskat
+ *
+ */
+public class Clitics {
+
+	// character sequences which have to be cut off at the beginning of a word
+	private String proclitic = "";
+
+	// character sequences which have to be cut off at the end of a word
+	private String enclitic = "";
+
+	public String getProclitic() {
+		return proclitic;
+	}
+	public Clitics setProclitic(String pClitic) {
+		proclitic = pClitic;
+		return this;
+	}
+	public String getEnclitic() {
+		return enclitic;
+	}
+	public Clitics setEnclitic(String fClitic) {
+		enclitic = fClitic;
+		return this;
+	}
+
+}

--- a/salt-api/src/main/java/org/corpus_tools/salt/common/tokenizer/Tokenizer.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/common/tokenizer/Tokenizer.java
@@ -134,7 +134,8 @@ public class Tokenizer {
 		}
 		if (this.getDocumentGraph() == null) {
 			if (sTextualDS.getGraph() == null) {
-				throw new SaltTokenizerException("Cannot add tokens to an empty SDocumentGraph object and can not estimate SDocumentGraph, because STextualDS does not belong to a SDocumentGraph object.");
+				throw new SaltTokenizerException(
+						"Cannot add tokens to an empty SDocumentGraph object and can not estimate SDocumentGraph, because STextualDS does not belong to a SDocumentGraph object.");
 			} else {
 				this.setsDocumentGraph(sTextualDS.getGraph());
 			}
@@ -163,17 +164,18 @@ public class Tokenizer {
 						this.addAbbreviation(LanguageCode.de, AbbreviationDE.createAbbriviations());
 					} else if (LanguageCode.en.equals(language)) {
 						this.addAbbreviation(LanguageCode.en, AbbreviationEN.createAbbriviations());
-						this.addClitics(LanguageCode.en, new Clitics()
-								.setEnclitic("('(s|re|ve|d|m|em|ll)|n't)"));
+						this.addClitics(LanguageCode.en, new Clitics(null, "('(s|re|ve|d|m|em|ll)|n't)"));
 					} else if (LanguageCode.fr.equals(language)) {
 						this.addAbbreviation(LanguageCode.fr, AbbreviationFR.createAbbriviations());
-						this.addClitics(LanguageCode.fr, new Clitics()
-								.setProclitic("([dcjlmnstDCJLNMST]'|[Qq]u'|[Jj]usqu'|[Ll]orsqu')")
-								.setEnclitic("(-t-elles?|-t-ils?|-t-on|-ce|-elles?|-ils?|-je|-la|-les?|-leur|-lui|-mêmes?|-m'|-moi|-nous|-on|-toi|-tu|-t'|-vous|-en|-y|-ci|-là)"));
+						this.addClitics(LanguageCode.fr, new Clitics(
+								"([dcjlmnstDCJLNMST]'|[Qq]u'|[Jj]usqu'|[Ll]orsqu')",
+								"(-t-elles?|-t-ils?|-t-on|-ce|-elles?|-ils?|-je|-la|-les?|-leur|-lui|-mêmes?|-m'|-moi|-nous|-on|-toi|-tu|-t'|-vous|-en|-y|-ci|-là)"));
 					} else if (LanguageCode.it.equals(language)) {
 						this.addAbbreviation(LanguageCode.it, AbbreviationIT.createAbbriviations());
-						this.addClitics(LanguageCode.it, new Clitics()
-								.setProclitic("([dD][ae]ll'|[nN]ell'|[Aa]ll'|[lLDd]'|[Ss]ull'|[Qq]uest'|[Uu]n'|[Ss]enz'|[Tt]utt')"));
+						this.addClitics(LanguageCode.it,
+								new Clitics(
+										"([dD][ae]ll'|[nN]ell'|[Aa]ll'|[lLDd]'|[Ss]ull'|[Qq]uest'|[Uu]n'|[Ss]enz'|[Tt]utt')",
+										null));
 					}
 				}
 			} // set abbreviations
@@ -277,7 +279,8 @@ public class Tokenizer {
 	 */
 	public void addAbbreviation(LanguageCode language, File abbreviationFile) {
 		HashSet<String> abbreviations = null;
-		try (BufferedReader inReader = new BufferedReader(new InputStreamReader(new FileInputStream(abbreviationFile), "UTF8"))) {
+		try (BufferedReader inReader = new BufferedReader(
+				new InputStreamReader(new FileInputStream(abbreviationFile), "UTF8"))) {
 			abbreviations = new HashSet<String>();
 
 			String input = "";
@@ -289,9 +292,11 @@ public class Tokenizer {
 			inReader.close();
 
 		} catch (FileNotFoundException e) {
-			throw new SaltTokenizerException("Cannot tokenize the given text, because the file for abbreviation '" + abbreviationFile.getAbsolutePath() + "' was not found.");
+			throw new SaltTokenizerException("Cannot tokenize the given text, because the file for abbreviation '"
+					+ abbreviationFile.getAbsolutePath() + "' was not found.");
 		} catch (IOException e) {
-			throw new SaltTokenizerException("Cannot tokenize the given text, because can not read file '" + abbreviationFile.getAbsolutePath() + "'.");
+			throw new SaltTokenizerException("Cannot tokenize the given text, because can not read file '"
+					+ abbreviationFile.getAbsolutePath() + "'.");
 		}
 		this.addAbbreviation(language, abbreviations);
 	}
@@ -321,8 +326,8 @@ public class Tokenizer {
 	private Map<LanguageCode, Clitics> clitics = new ConcurrentHashMap<>();
 
 	/**
-	 * Adds the given clitics to the internal map corresponding to
-	 * given language.
+	 * Adds the given clitics to the internal map corresponding to given
+	 * language.
 	 * 
 	 * @param language
 	 * @param clitics
@@ -336,11 +341,12 @@ public class Tokenizer {
 	}
 
 	/**
-	 * Adds the content of given file as a set of clitics to the internal
-	 * map corresponding to given language. Form of the file: Adm.<br/>
+	 * Adds the content of given file as a set of clitics to the internal map
+	 * corresponding to given language. Form of the file: Adm.<br/>
 	 * <p>
-	 * The file must be structured so that the first line contains the regex for <b>proclitics</b>,
-	 * and the second line the regex for <b>enclitics</b>, e.g.:
+	 * The file must be structured so that the first line contains the regex for
+	 * <b>proclitics</b>, and the second line the regex for <b>enclitics</b>,
+	 * e.g.:
 	 * <p>
 	 * <code>
 	 * ([dcjlmnstDCJLNMST]'|[Qq]u'|[Jj]usqu'|[Ll]orsqu')
@@ -352,25 +358,29 @@ public class Tokenizer {
 	 */
 	public void addClitics(LanguageCode language, File cliticsFile) {
 		Clitics clitics = null;
-		try (BufferedReader inReader = new BufferedReader(new InputStreamReader(new FileInputStream(cliticsFile), "UTF8"))) {
-			clitics = new Clitics();
+		try (BufferedReader inReader = new BufferedReader(
+				new InputStreamReader(new FileInputStream(cliticsFile), "UTF8"))) {
+			String proclicits = null;
+			String enclitics = null;
 			String input = "";
 			int lineNumber = 0;
 			while ((input = inReader.readLine()) != null) {
 				lineNumber++;
 				if (lineNumber == 1) {
-					clitics.setProclitic(input);
-				}
-				else if (lineNumber == 2) {
-					clitics.setEnclitic(input);
+					proclicits = input;
+				} else if (lineNumber == 2) {
+					enclitics = input;
 				}
 			}
+			clitics = new Clitics(proclicits, enclitics);
 			inReader.close();
 
 		} catch (FileNotFoundException e) {
-			throw new SaltTokenizerException("Cannot tokenize the given text, because the file for clitics '" + cliticsFile.getAbsolutePath() + "' was not found.");
+			throw new SaltTokenizerException("Cannot tokenize the given text, because the file for clitics '"
+					+ cliticsFile.getAbsolutePath() + "' was not found.");
 		} catch (IOException e) {
-			throw new SaltTokenizerException("Cannot tokenize the given text, because the clitics file '" + cliticsFile.getAbsolutePath() + "' cannot be read.");
+			throw new SaltTokenizerException("Cannot tokenize the given text, because the clitics file '"
+					+ cliticsFile.getAbsolutePath() + "' cannot be read.");
 		}
 		this.addClitics(language, clitics);
 	}
@@ -388,7 +398,7 @@ public class Tokenizer {
 		}
 		return (retVal);
 	}
-	
+
 	/**
 	 * The general task of this class is to tokenize a given text in the same
 	 * order as the tool TreeTagger will do. A list of tokenized text is
@@ -404,7 +414,8 @@ public class Tokenizer {
 	 *            original text
 	 * @return tokenized text fragments and their position in the original text
 	 */
-	public List<SToken> tokenizeToToken(STextualDS sTextualDS, LanguageCode language, Integer startPos, Integer endPos) {
+	public List<SToken> tokenizeToToken(STextualDS sTextualDS, LanguageCode language, Integer startPos,
+			Integer endPos) {
 		List<SToken> retVal = null;
 		List<String> strTokens = null;
 		String strInput = sTextualDS.getText().substring(startPos, endPos);
@@ -416,7 +427,8 @@ public class Tokenizer {
 
 			// check if tokens exist for passed span
 			List<SToken> tokens = null;
-			if ((startPos != 0) || (endPos != sTextualDS.getText().length()) || (getDocumentGraph().getTextualDSs().size() > 1)) {
+			if ((startPos != 0) || (endPos != sTextualDS.getText().length())
+					|| (getDocumentGraph().getTextualDSs().size() > 1)) {
 				DataSourceSequence sequence = new DataSourceSequence();
 				sequence.setDataSource(sTextualDS);
 				sequence.setStart(startPos);
@@ -430,7 +442,8 @@ public class Tokenizer {
 			// create an organization structure for a tokens interval which
 			// corresponds to a token
 			if ((tokens != null) && (tokens.size() != 0)) {
-				if ((getDocumentGraph().getTextualRelations() != null) && (getDocumentGraph().getTextualRelations().size() > 0)) {
+				if ((getDocumentGraph().getTextualRelations() != null)
+						&& (getDocumentGraph().getTextualRelations().size() > 0)) {
 					oldTokens = TreeRangeMap.create();
 					for (STextualRelation rel : getDocumentGraph().getTextualRelations()) {
 						oldTokens.put(Range.closed(rel.getStart(), rel.getEnd()), rel.getSource());
@@ -443,7 +456,8 @@ public class Tokenizer {
 			Multimap<SToken, SToken> old2newToken = ArrayListMultimap.create();
 
 			for (int i = 0; i < chrText.length; i++) {
-				if ((strTokens.get(tokenCntr).length() < 1) || (strTokens.get(tokenCntr).substring(0, 1).equals(String.valueOf(chrText[i])))) {
+				if ((strTokens.get(tokenCntr).length() < 1)
+						|| (strTokens.get(tokenCntr).substring(0, 1).equals(String.valueOf(chrText[i])))) {
 					// first letter matches
 					StringBuffer pattern = new StringBuffer();
 					for (int y = 0; y < strTokens.get(tokenCntr).length(); y++) {
@@ -638,11 +652,14 @@ public class Tokenizer {
 			}
 
 			// attempt to separate proclitics
-			if (getClitics(language)!= null && getClitics(language).getProclitic() != null) {
-			p = Pattern.compile("^" + getClitics(language).getProclitic() + "(.+)$");
-			String token = lstTokens.get(i);
+			
+			Clitics languageClitics;
+			String proclitics;
+			if ((languageClitics = getClitics(language)) != null && (proclitics = languageClitics.getProclitics()) != null) {
+				p = Pattern.compile("^" + proclitics + "(.+)$");
+				String token = lstTokens.get(i);
 				m = p.matcher(token);
-				if (m.find() && (!getClitics(language).getProclitic().isEmpty())) {
+				if (m.find() && (!proclitics.isEmpty())) {
 					lstTokens.remove(i);
 					lstTokens.add(i, m.group(2));
 					lstTokens.add(i, m.group(1));
@@ -651,18 +668,19 @@ public class Tokenizer {
 				}
 			}
 
+			String enclitics;
 			// attempt to separate enclitics
-				if (getClitics(language) != null && getClitics(language).getEnclitic() != null) {
-				p = Pattern.compile("(.+)" + getClitics(language).getEnclitic() + "$");
+			if (languageClitics != null && (enclitics = languageClitics.getEnclitics()) != null) {
+				p = Pattern.compile("(.+)" + enclitics + "$");
 				m = p.matcher(lstTokens.get(i));
-				if (m.find() && (!getClitics(language).getEnclitic().isEmpty())) {
+				if (m.find() && (!enclitics.isEmpty())) {
 					lstTokens.remove(i);
 					lstTokens.add(i, m.group(2));
 					lstTokens.add(i, m.group(1));
 					i++; // next token is a known enclitic, skip it
 					continue; // advance to get past the enclitic
 				}
-				}
+			}
 
 		}
 		return lstTokens;

--- a/salt-api/src/main/java/org/corpus_tools/salt/common/tokenizer/Tokenizer.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/common/tokenizer/Tokenizer.java
@@ -153,7 +153,7 @@ public class Tokenizer {
 				// if text was to short to emit language try entire text (and
 				// hope, that no language mixes are contained :-})
 				if (language == null) {
-					language = checkLanguage(sTextualDS.getText().substring(startPos, endPos));
+					language = checkLanguage(sTextualDS.getText());
 				}
 			}
 

--- a/salt-api/src/main/java/org/corpus_tools/salt/common/tokenizer/Tokenizer.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/common/tokenizer/Tokenizer.java
@@ -172,10 +172,9 @@ public class Tokenizer {
 								"(-t-elles?|-t-ils?|-t-on|-ce|-elles?|-ils?|-je|-la|-les?|-leur|-lui|-mêmes?|-m'|-moi|-nous|-on|-toi|-tu|-t'|-vous|-en|-y|-ci|-là)"));
 					} else if (LanguageCode.it.equals(language)) {
 						this.addAbbreviation(LanguageCode.it, AbbreviationIT.createAbbriviations());
-						this.addClitics(LanguageCode.it,
-								new Clitics(
-										"([dD][ae]ll'|[nN]ell'|[Aa]ll'|[lLDd]'|[Ss]ull'|[Qq]uest'|[Uu]n'|[Ss]enz'|[Tt]utt')",
-										null));
+						this.addClitics(LanguageCode.it, new Clitics(
+								"([dD][ae]ll'|[nN]ell'|[Aa]ll'|[lLDd]'|[Ss]ull'|[Qq]uest'|[Uu]n'|[Ss]enz'|[Tt]utt')",
+								null));
 					}
 				}
 			} // set abbreviations

--- a/salt-api/src/test/java/org/corpus_tools/salt/common/impl/tests/STextualDSTest.java
+++ b/salt-api/src/test/java/org/corpus_tools/salt/common/impl/tests/STextualDSTest.java
@@ -17,10 +17,14 @@
  */
 package org.corpus_tools.salt.common.impl.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
+
+import java.util.List;
 
 import org.corpus_tools.salt.SaltFactory;
+import org.corpus_tools.salt.common.SDocumentGraph;
 import org.corpus_tools.salt.common.STextualDS;
+import org.corpus_tools.salt.common.SToken;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -83,5 +87,23 @@ public class STextualDSTest extends SSequentialDSTest<String, Integer> {
 		assertEquals(null, getFixture().getEnd());
 		getFixture().setData("Test");
 		assertEquals(Integer.valueOf(4), getFixture().getEnd());
+	}
+	
+	@Test
+	public void testTokenize() {
+		SDocumentGraph graph = SaltFactory.createSDocumentGraph();
+		getFixture().setText("This is a birthday pony!");
+		getFixture().setGraph(graph);
+		List<SToken> tokens = getFixture().tokenize();
+		graph = getFixture().getGraph();
+		assertNotNull(graph);
+		assertTrue(graph instanceof SDocumentGraph);
+		tokens = graph.getSortedTokenByText();
+		assertNotNull(tokens);
+		assertTrue(tokens.size() == 6);
+		String[] tokenArray = new String[]{"This", "is", "a", "birthday", "pony", "!"};
+		for (int i = 0; i < graph.getTokens().size(); i++) {
+		assertEquals(tokenArray[i], graph.getText(tokens.get(i)));
+		}
 	}
 } // STextualDSTest

--- a/salt-api/src/test/java/org/corpus_tools/salt/common/tokenizer/tests/TokenizerTest.java
+++ b/salt-api/src/test/java/org/corpus_tools/salt/common/tokenizer/tests/TokenizerTest.java
@@ -40,6 +40,7 @@ import com.neovisionaries.i18n.LanguageCode;
  * Tests the class TTTokenizer.
  * 
  * @author Florian Zipser
+ * @author Stephan Druskat (Clitics tests)
  *
  */
 public class TokenizerTest {
@@ -471,7 +472,7 @@ public class TokenizerTest {
 		
 		SDocumentGraph sDocGraph = SaltFactory.createSDocumentGraph();
 		STextualDS sTextualDS = sDocGraph.createTextualDS(fantasy);
-		getFixture().addClitics(LanguageCode.aa, new Clitics().setProclitic(fantasyProclitics).setEnclitic(fantasyEnclitics));
+		getFixture().addClitics(LanguageCode.aa, new Clitics(fantasyProclitics, fantasyEnclitics));
 		getFixture().tokenize(sTextualDS, LanguageCode.aa); // Borrowed language code
 
 		int i = 0;

--- a/salt-api/src/test/java/org/corpus_tools/salt/common/tokenizer/tests/TokenizerTest.java
+++ b/salt-api/src/test/java/org/corpus_tools/salt/common/tokenizer/tests/TokenizerTest.java
@@ -28,6 +28,7 @@ import org.corpus_tools.salt.SaltFactory;
 import org.corpus_tools.salt.common.SDocumentGraph;
 import org.corpus_tools.salt.common.STextualDS;
 import org.corpus_tools.salt.common.STextualRelation;
+import org.corpus_tools.salt.common.tokenizer.Clitics;
 import org.corpus_tools.salt.common.tokenizer.Tokenizer;
 import org.junit.Before;
 import org.junit.Test;
@@ -346,6 +347,132 @@ public class TokenizerTest {
 		getFixture().tokenize(sTextualDS, LanguageCode.en);
 
 		assertEquals(expectedToken.size(), sDocGraph.getTokens().size());
+		
+		int i = 0;
+		for (STextualRelation sTextRel : sDocGraph.getTextualRelations()) {
+			assertTrue(expectedToken.size() >= i);
+			assertNotNull(expectedToken.get(i));
+			assertNotNull(sTextRel.getSource());
+			assertNotNull(sTextRel.getTarget());
+			assertEquals(expectedToken.get(i).startPos, sTextRel.getStart());
+			assertEquals(expectedToken.get(i).endPos, sTextRel.getEnd());
+			assertEquals(expectedToken.get(i).text, sTextRel.getTarget().getText().substring(sTextRel.getStart(), sTextRel.getEnd()));
+			i++;
+		}
+		
+	}
+	
+	@Test
+	public void testDefaultClitics() {
+		String francais = "ou ceux-là mêmes qu'il s'affirmaient";
+		String italiano = "Riuscire all'università";
+		List<Token> expectedItalianoToken = new Vector<Token>();
+		List<Token> expectedFrancaisToken = new Vector<Token>();
+		expectedItalianoToken.add(new Token("Riuscire", 0, 8));
+		expectedItalianoToken.add(new Token("all'", 9, 13));
+		expectedItalianoToken.add(new Token("università", 13, 23));
+
+		expectedFrancaisToken.add(new Token("ou", 0, 2));
+		expectedFrancaisToken.add(new Token("ceux", 3, 7));
+		expectedFrancaisToken.add(new Token("-là", 7, 10));
+		expectedFrancaisToken.add(new Token("mêmes", 11, 16));
+		expectedFrancaisToken.add(new Token("qu'", 17, 20));
+		expectedFrancaisToken.add(new Token("il", 20, 22));
+		expectedFrancaisToken.add(new Token("s'", 23, 25));
+		expectedFrancaisToken.add(new Token("affirmaient", 25, 36));
+
+		SDocumentGraph sDocGraph = SaltFactory.createSDocumentGraph();
+		STextualDS sTextualDS = sDocGraph.createTextualDS(francais);
+		getFixture().setsDocumentGraph(sDocGraph);
+		getFixture().tokenize(sTextualDS, LanguageCode.fr);
+		
+		int i = 0;
+		for (STextualRelation sTextRel : sDocGraph.getTextualRelations()) {
+			assertTrue(expectedFrancaisToken.size() >= i);
+			assertNotNull(expectedFrancaisToken.get(i));
+			assertNotNull(sTextRel.getSource());
+			assertNotNull(sTextRel.getTarget());
+			assertEquals(expectedFrancaisToken.get(i).startPos, sTextRel.getStart());
+			assertEquals(expectedFrancaisToken.get(i).endPos, sTextRel.getEnd());
+			assertEquals(expectedFrancaisToken.get(i).text, sTextRel.getTarget().getText().substring(sTextRel.getStart(), sTextRel.getEnd()));
+			i++;
+		}
+
+		sDocGraph = SaltFactory.createSDocumentGraph();
+		sTextualDS = sDocGraph.createTextualDS(italiano);
+		getFixture().setsDocumentGraph(sDocGraph);
+		getFixture().tokenize(sTextualDS, LanguageCode.it);
+		
+		i = 0;
+		for (STextualRelation sTextRel : sDocGraph.getTextualRelations()) {
+			assertTrue(expectedItalianoToken.size() >= i);
+			assertNotNull(expectedItalianoToken.get(i));
+			assertNotNull(sTextRel.getSource());
+			assertNotNull(sTextRel.getTarget());
+			assertEquals(expectedItalianoToken.get(i).startPos, sTextRel.getStart());
+			assertEquals(expectedItalianoToken.get(i).endPos, sTextRel.getEnd());
+			assertEquals(expectedItalianoToken.get(i).text, sTextRel.getTarget().getText().substring(sTextRel.getStart(), sTextRel.getEnd()));
+			i++;
+		}
+		
+		sDocGraph = SaltFactory.createSDocumentGraph();
+		sTextualDS = sDocGraph.createTextualDS(francais);
+		getFixture().setsDocumentGraph(sDocGraph);
+		getFixture().tokenize(sTextualDS); // No language code
+		
+		i = 0;
+		for (STextualRelation sTextRel : sDocGraph.getTextualRelations()) {
+			assertTrue(expectedFrancaisToken.size() >= i);
+			assertNotNull(expectedFrancaisToken.get(i));
+			assertNotNull(sTextRel.getSource());
+			assertNotNull(sTextRel.getTarget());
+			assertEquals(expectedFrancaisToken.get(i).startPos, sTextRel.getStart());
+			assertEquals(expectedFrancaisToken.get(i).endPos, sTextRel.getEnd());
+			assertEquals(expectedFrancaisToken.get(i).text, sTextRel.getTarget().getText().substring(sTextRel.getStart(), sTextRel.getEnd()));
+			i++;
+		}
+
+		sDocGraph = SaltFactory.createSDocumentGraph();
+		sTextualDS = sDocGraph.createTextualDS(italiano);
+		getFixture().setsDocumentGraph(sDocGraph);
+		getFixture().tokenize(sTextualDS); // No language code
+		
+		i = 0;
+		for (STextualRelation sTextRel : sDocGraph.getTextualRelations()) {
+			assertTrue(expectedItalianoToken.size() >= i);
+			assertNotNull(expectedItalianoToken.get(i));
+			assertNotNull(sTextRel.getSource());
+			assertNotNull(sTextRel.getTarget());
+			assertEquals(expectedItalianoToken.get(i).startPos, sTextRel.getStart());
+			assertEquals(expectedItalianoToken.get(i).endPos, sTextRel.getEnd());
+			assertEquals(expectedItalianoToken.get(i).text, sTextRel.getTarget().getText().substring(sTextRel.getStart(), sTextRel.getEnd()));
+			i++;
+		}
+	}
+	
+	@Test
+	public void testFantasyClitics() {
+		String fantasy = "S Z-S-z X-S-x Y^S^y Z.S.z x^S.Y";
+		String fantasyProclitics = "([Xx]-|[Yy]\\^|[Zz]\\.)";
+		String fantasyEnclitics = "(-[Xx]|\\^[Yy]|\\.[Zz])";
+		List<Token> expectedToken = new Vector<Token>();
+		expectedToken.add(new Token("S", 0, 1));
+		expectedToken.add(new Token("Z-S-z", 2, 7));
+		expectedToken.add(new Token("X-", 8, 10));
+		expectedToken.add(new Token("S", 10, 11));
+		expectedToken.add(new Token("-x", 11, 13));
+		expectedToken.add(new Token("Y^", 14, 16));
+		expectedToken.add(new Token("S", 16, 17));
+		expectedToken.add(new Token("^y", 17, 19));
+		expectedToken.add(new Token("Z.", 20, 22));
+		expectedToken.add(new Token("S", 22, 23));
+		expectedToken.add(new Token(".z", 23, 25));
+		expectedToken.add(new Token("x^S.Y", 26, 31));
+		
+		SDocumentGraph sDocGraph = SaltFactory.createSDocumentGraph();
+		STextualDS sTextualDS = sDocGraph.createTextualDS(fantasy);
+		getFixture().addClitics(LanguageCode.aa, new Clitics().setProclitic(fantasyProclitics).setEnclitic(fantasyEnclitics));
+		getFixture().tokenize(sTextualDS, LanguageCode.aa); // Borrowed language code
 
 		int i = 0;
 		for (STextualRelation sTextRel : sDocGraph.getTextualRelations()) {
@@ -358,5 +485,6 @@ public class TokenizerTest {
 			assertEquals(expectedToken.get(i).text, sTextRel.getTarget().getText().substring(sTextRel.getStart(), sTextRel.getEnd()));
 			i++;
 		}
+
 	}
 }


### PR DESCRIPTION
- Fix #69
- Fix #86
- Fix #87
- Add dynamic clitics support, i.e., the ability to set proclitics and enclitics on a specific language (referenced by LanguageCode) in Tokenizer, similar to how abbreviations work.
- Add tests

