### PR TITLE
Fix #123: Rename method getLayerByName

### DIFF
--- a/salt-api/src/main/java/org/corpus_tools/salt/core/SGraph.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/core/SGraph.java
@@ -169,6 +169,18 @@ public interface SGraph
 	 * @param layerName
 	 *            Name of the layer to search for
 	 * @return A complete list of all matching layers. Is never null.
+	 * @deprecated Use {@link #getLayersByName(String)}
 	 */
+	@Deprecated
 	public List<SLayer> getLayerByName(String layerName);
+	
+	/**
+	 * Searches for a layer or a set of layers having the given layer name.
+	 * 
+	 * @param layerName
+	 *            Name of the layer to search for
+	 * @return A complete list of all matching layers. Is never null.
+	 */
+	public List<SLayer> getLayersByName(String layerName);
+	
 }

--- a/salt-api/src/main/java/org/corpus_tools/salt/core/impl/SGraphImpl.java
+++ b/salt-api/src/main/java/org/corpus_tools/salt/core/impl/SGraphImpl.java
@@ -106,7 +106,27 @@ public class SGraphImpl extends GraphImpl<SNode, SRelation<SNode, SNode>, SLayer
 
 	/** {@inheritDoc} **/
 	@Override
+	@Deprecated
 	public List<SLayer> getLayerByName(String layerName) {
+		if ((layerName == null) || (layerName.isEmpty())) {
+			return (null);
+		}
+
+		List<SLayer> result = new ArrayList<>();
+		for (SLayer l : getLayers()) {
+			if ((l.getName() == null) || (l.getName().isEmpty())) {
+				break;
+			}
+			if (layerName.equals(l.getName())) {
+				result.add(l);
+			}
+		}
+		return result;
+	}
+
+	/** {@inheritDoc} **/
+	@Override
+	public List<SLayer> getLayersByName(String layerName) {
 		if ((layerName == null) || (layerName.isEmpty())) {
 			return (null);
 		}


### PR DESCRIPTION
Deprecates the old method and adds a new one with the same functionality and added 's' in the method name.